### PR TITLE
Feat: #16 typeorm-transactional 라이브러리 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "swagger-ui-express": "^5.0.1",
     "typeorm": "^0.3.20",
     "typeorm-naming-strategies": "^4.1.0",
+    "typeorm-transactional": "^0.5.0",
     "uuid": "^10.0.0"
   },
   "devDependencies": {

--- a/src/common/database.module.ts
+++ b/src/common/database.module.ts
@@ -12,6 +12,8 @@ import { TownCities } from '@/geography/entities/town-cities.entity';
 import { CountryStates } from '@/geography/entities/country-states.entity';
 
 import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
+import { DataSource } from 'typeorm';
+import { addTransactionalDataSource } from 'typeorm-transactional';
 
 @Module({
   imports: [
@@ -46,6 +48,12 @@ import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
           },
         },
       }),
+      async dataSourceFactory(option) {
+        if (!option) {
+          throw new Error('Invalid options passed');
+        }
+        return addTransactionalDataSource(new DataSource(option));
+      },
       inject: [ConfigService],
     }),
   ],

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,8 +7,11 @@ import {
   VersioningType,
 } from '@nestjs/common';
 import { CaseConverterInterceptor } from '@/common/interceptors/case-converter.interceptor';
+import { initializeTransactionalContext } from 'typeorm-transactional';
 
 async function bootstrap() {
+  initializeTransactionalContext();
+
   const app = await NestFactory.create(AppModule);
   app.setGlobalPrefix('api');
   app.enableVersioning({


### PR DESCRIPTION
## 기능 설명
- `@Transactional` 을 사용하기 위해 `typeorm-transactional` 라이브러리 추가

## 추가 정보
- [참고 블로그 ](https://velog.io/@wndbsgkr/NestJS%EC%97%90%EC%84%9C-Transaction-%EC%82%AC%EC%9A%A9%ED%95%98%EA%B8%B0feat.-TypeORM)