### PR TITLE
Fix: #28 travels, travel-details, travel-locations 날짜 포맷 수정

### DIFF
--- a/src/travel/dto/create-travel-details.dto.ts
+++ b/src/travel/dto/create-travel-details.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsInt, IsOptional, IsString } from 'class-validator';
+import { IsInt, IsISO8601, IsOptional, IsString } from 'class-validator';
 
 export class CreateTravelDetailsDto {
   @IsOptional()
@@ -26,19 +26,19 @@ export class CreateTravelDetailsDto {
   })
   description: string | null;
 
-  @IsDateString()
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-01T00:00:00',
-    description: 'start date of the travel detail',
+    example: '2024-02-01T00:00:00Z',
+    description: 'start date of the travel in ISO8601 format',
   })
-  startDate: Date;
+  startDate: string;
 
-  @IsDateString()
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-02T00:00:00',
-    description: 'end date of the travel detail',
+    example: '2024-02-02T00:00:00Z',
+    description: 'end date of the travel in ISO8601 format',
   })
-  endDate: Date;
+  endDate: string;
 
   @IsInt()
   @ApiProperty({

--- a/src/travel/dto/create-travel-locations.dto.ts
+++ b/src/travel/dto/create-travel-locations.dto.ts
@@ -1,8 +1,8 @@
 import { LocationType } from '@/travel/enums/location-type';
 import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsDateString,
   IsInt,
+  IsISO8601,
   IsNumber,
   IsOptional,
   IsString,
@@ -72,19 +72,19 @@ export class CreateTravelLocationsDto {
   })
   orderIndex: number;
 
-  @IsDateString()
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-01T00:00:00',
-    description: 'start date of the travel detail',
+    example: '2024-02-01T00:00:00Z',
+    description: 'start date of the travel in ISO8601 format',
   })
-  startDate: Date;
+  startDate: string;
 
-  @IsDateString()
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-02T00:00:00',
-    description: 'end date of the travel detail',
+    example: '2024-02-02T00:00:00Z',
+    description: 'end date of the travel in ISO8601 format',
   })
-  endDate: Date;
+  endDate: string;
 
   @IsInt()
   @ApiProperty({

--- a/src/travel/dto/create-travel.dto.ts
+++ b/src/travel/dto/create-travel.dto.ts
@@ -1,42 +1,59 @@
 import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class CreateTravelDto {
+  @IsBoolean()
   @ApiProperty({
     example: false,
     description: 'shared status of the travel',
   })
   isShared: boolean;
 
+  @IsOptional()
+  @IsString()
   @ApiProperty({
     example: 'icon',
     description: 'icon of the travel',
   })
-  icon: string;
+  icon?: string | null;
 
+  @IsOptional()
+  @IsString()
   @ApiProperty({
     example: 'title',
     description: 'title of the travel',
   })
-  title: string;
+  title?: string | null;
 
+  @IsOptional()
+  @IsString()
   @ApiProperty({
     example: 'description',
     description: 'description of the travel',
   })
-  description: string;
+  description?: string | null;
 
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-01T00:00:00',
-    description: 'start date of the travel',
+    example: '2024-02-01T00:00:00Z',
+    description: 'start date of the travel in ISO8601 format',
   })
-  startDate: Date;
+  startDate: string;
 
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-02T00:00:00',
-    description: 'end date of the travel',
+    example: '2024-02-02T00:00:00Z',
+    description: 'end date of the travel in ISO8601 format',
   })
-  endDate: Date;
+  endDate: string;
 
+  @IsInt()
   @ApiProperty({
     example: 1,
     description: 'creator id of the travel',

--- a/src/travel/dto/update-travel-details.dto.ts
+++ b/src/travel/dto/update-travel-details.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDateString, IsInt, IsOptional, IsString } from 'class-validator';
+import { IsInt, IsISO8601, IsOptional, IsString } from 'class-validator';
 
 export class UpdateTravelDetailsDto {
   @IsInt()
@@ -33,17 +33,17 @@ export class UpdateTravelDetailsDto {
   })
   description: string | null;
 
-  @IsDateString()
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-01T00:00:00',
-    description: 'start date of the travel detail',
+    example: '2024-02-01T00:00:00Z',
+    description: 'start date of the travel in ISO8601 format',
   })
-  startDate: Date;
+  startDate: string;
 
-  @IsDateString()
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-02T00:00:00',
-    description: 'end date of the travel detail',
+    example: '2024-02-02T00:00:00Z',
+    description: 'end date of the travel in ISO8601 format',
   })
-  endDate: Date;
+  endDate: string;
 }

--- a/src/travel/dto/update-travel-location.dto.ts
+++ b/src/travel/dto/update-travel-location.dto.ts
@@ -1,8 +1,8 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { LocationType } from '@/travel/enums/location-type';
 import {
-  IsDateString,
   IsInt,
+  IsISO8601,
   IsNumber,
   IsOptional,
   IsString,
@@ -79,19 +79,19 @@ export class UpdateTravelLocationDto {
   })
   orderIndex: number;
 
-  @IsDateString()
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-01T00:00:00',
-    description: 'start date of the travel detail',
+    example: '2024-02-01T00:00:00Z',
+    description: 'start date of the travel in ISO8601 format',
   })
-  startDate: Date;
+  startDate: string;
 
-  @IsDateString()
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-02-02T00:00:00',
-    description: 'end date of the travel detail',
+    example: '2024-02-02T00:00:00Z',
+    description: 'end date of the travel in ISO8601 format',
   })
-  endDate: Date;
+  endDate: string;
 
   @IsInt()
   @ApiProperty({

--- a/src/travel/dto/update-travel.dto.ts
+++ b/src/travel/dto/update-travel.dto.ts
@@ -1,45 +1,62 @@
 import { ApiProperty } from '@nestjs/swagger';
+import {
+  IsBoolean,
+  IsInt,
+  IsISO8601,
+  IsOptional,
+  IsString,
+} from 'class-validator';
 
 export class UpdateTravelDto {
+  @IsInt()
   @ApiProperty({
     example: 1,
     description: 'The id of the travel',
   })
   id: bigint;
 
+  @IsBoolean()
   @ApiProperty({
     example: true,
     description: 'The shared status of the travel',
   })
   isShared: boolean;
 
+  @IsOptional()
+  @IsString()
   @ApiProperty({
     example: 'icon',
     description: 'The icon of the travel',
   })
-  icon: string;
+  icon?: string | null;
 
+  @IsOptional()
+  @IsString()
   @ApiProperty({
     example: 'title',
     description: 'The title of the travel',
   })
-  title: string;
+  title?: string | null;
 
+  @IsOptional()
+  @IsString()
   @ApiProperty({
     example: 'description',
     description: 'The description of the travel',
   })
-  description: string;
+  description?: string | null;
 
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-01-01T00:00:00Z',
-    description: 'The start date of the travel',
+    example: '2024-02-01T00:00:00Z',
+    description: 'start date of the travel in ISO8601 format',
   })
-  startDate: Date;
+  startDate: string;
 
+  @IsISO8601()
   @ApiProperty({
-    example: '2024-01-02T00:00:00Z',
-    description: 'The end date of the travel',
+    example: '2024-02-02T00:00:00Z',
+    description: 'end date of the travel in ISO8601 format',
   })
-  endDate: Date;
+  endDate: string;
 }

--- a/src/travel/service/travel-details.service.ts
+++ b/src/travel/service/travel-details.service.ts
@@ -4,7 +4,6 @@ import { Repository } from 'typeorm';
 import { TravelDetails } from '@/travel/entities/travel-details.entity';
 import { InjectRepository } from '@nestjs/typeorm';
 import { CreateTravelDetailsDto } from '@/travel/dto/create-travel-details.dto';
-import { toZonedTime } from 'date-fns-tz';
 import { TravelsService } from '@/travel/service/travels.service';
 import { Transactional } from 'typeorm-transactional';
 import { UpdateTravelDetailsDto } from '@/travel/dto/update-travel-details.dto';
@@ -38,14 +37,10 @@ export class TravelDetailsService extends SearchFilterService {
       createTravelDetailDto;
 
     const travel = await this.travelsService.findTravelDeep(travelId);
-
-    const zoneStartDate = toZonedTime(startDate, 'Asia/Seoul');
-    const zoneEndDate = toZonedTime(endDate, 'Asia/Seoul');
-
     const travelDetail = this.travelDetailRepository.create({
       ...travelDetailData,
-      startDate: zoneStartDate,
-      endDate: zoneEndDate,
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
       travel,
     });
     return await this.travelDetailRepository.save(travelDetail);
@@ -176,21 +171,13 @@ export class TravelDetailsService extends SearchFilterService {
 
     const travelDetail = await this.findOneTravelDetailDeep(id);
 
-    const zoneStartDate = toZonedTime(startDate, 'Asia/Seoul');
-    const zoneEndDate = toZonedTime(endDate, 'Asia/Seoul');
-
     Object.assign(travelDetail, {
       ...travelDetailData,
-      startDate: zoneStartDate,
-      endDate: zoneEndDate,
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
     });
-    try {
-      return await this.travelDetailRepository.save(travelDetail);
-    } catch (error) {
-      throw new Error(
-        `Failed to update TravelDetails with id ${id}: ${error.message}`,
-      );
-    }
+
+    return await this.travelDetailRepository.save(travelDetail);
   }
 
   /**

--- a/src/travel/service/travel-locations.service.ts
+++ b/src/travel/service/travel-locations.service.ts
@@ -4,7 +4,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { TravelLocations } from '@/travel/entities/travel-locations.entity';
 import { Repository } from 'typeorm';
 import { TravelDetailsService } from '@/travel/service/travel-details.service';
-import { fromZonedTime } from 'date-fns-tz';
 import { CreateTravelLocationsDto } from '@/travel/dto/create-travel-locations.dto';
 import { TownCitiesService } from '@/geography/service/town-cities.service';
 import { Transactional } from 'typeorm-transactional';
@@ -26,6 +25,7 @@ export class TravelLocationsService extends SearchFilterService {
 
   /**
    * 여행지 장소 생성
+   *
    * @param createTravelLocationsDto
    */
   @Transactional()
@@ -46,13 +46,10 @@ export class TravelLocationsService extends SearchFilterService {
       throw new Error(`TownCity with id ${townCityId} not found`);
     }
 
-    const zoneStartDate = fromZonedTime(startDate, 'Asia/Seoul');
-    const zoneEndDate = fromZonedTime(endDate, 'Asia/Seoul');
-
     const location = this.travelLocationsRepository.create({
       ...locationData,
-      startDate: zoneStartDate,
-      endDate: zoneEndDate,
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
       travelDetails,
       townCities,
     });
@@ -155,13 +152,10 @@ export class TravelLocationsService extends SearchFilterService {
       throw new Error(`TownCity with id ${townCityId} not found`);
     }
 
-    const zoneStartDate = fromZonedTime(startDate, 'Asia/Seoul');
-    const zoneEndDate = fromZonedTime(endDate, 'Asia/Seoul');
-
     Object.assign(location, {
       ...locationData,
-      startDate: zoneStartDate,
-      endDate: zoneEndDate,
+      startDate: new Date(startDate),
+      endDate: new Date(endDate),
       travelDetails: travelDetail,
       townCities: townCity,
     });


### PR DESCRIPTION
- `travels`, `travel-details`, `travel-locations`  각 테이블의 CREATE, UPDATE 시 날짜 포맷을 `ISO8601` 포맷으로 맞춤
- 프론트에서 백엔드로 날짜 삽입시 UTC 기준으로 삽입 예정(ex: `2024-02-01T00:00:00.000Z`)