### PR TITLE
fix: #47 updateTravel 시 travel-detail 연관관계 삭제 버그 수정

### DIFF
--- a/src/travel/controller/travels.controller.ts
+++ b/src/travel/controller/travels.controller.ts
@@ -183,7 +183,7 @@ export class TravelsController {
       travelId,
     );
   }
-  // TODO: 버그 수정 확인 필요함
+
   @Put()
   @UseGuards(UserGuard)
   @ApiOperation({ summary: '여행 수정' })

--- a/src/travel/dto/update-travel.dto.ts
+++ b/src/travel/dto/update-travel.dto.ts
@@ -5,7 +5,10 @@ import {
   IsISO8601,
   IsOptional,
   IsString,
+  ValidateNested,
 } from 'class-validator';
+import { Type } from 'class-transformer';
+import { TravelDetails } from '@/travel/entities/travel-details.entity';
 
 export class UpdateTravelDto {
   @IsInt()
@@ -59,4 +62,13 @@ export class UpdateTravelDto {
     description: 'end date of the travel in ISO8601 format',
   })
   endDate: string;
+
+  @IsOptional()
+  @ValidateNested({ each: true })
+  @Type(() => TravelDetails)
+  @ApiProperty({
+    type: [TravelDetails],
+    description: 'The details of the travel',
+  })
+  travelDetails?: TravelDetails[];
 }

--- a/src/travel/service/travels.service.ts
+++ b/src/travel/service/travels.service.ts
@@ -272,7 +272,8 @@ export class TravelsService extends SearchFilterService {
    */
   @Transactional()
   async updateTravel(updateTravelDto: UpdateTravelDto): Promise<Travels> {
-    const { startDate, endDate, ...travelData } = updateTravelDto;
+    const { startDate, endDate, travelDetails, ...travelData } =
+      updateTravelDto;
     const travel = await this.findTravelDeep(updateTravelDto.id);
 
     if (!travel) {
@@ -286,6 +287,18 @@ export class TravelsService extends SearchFilterService {
       startDate: new Date(startDate),
       endDate: new Date(endDate),
     });
+
+    if (travelDetails) {
+      // 기존 travelDetails를 유지하면서 업데이트
+      travel.travelDetails = travel.travelDetails.map((existingDetail) => {
+        const updatedDetail = travelDetails.find(
+          (detail) => detail._id === existingDetail._id,
+        );
+        return updatedDetail
+          ? { ...existingDetail, ...updatedDetail }
+          : existingDetail;
+      });
+    }
 
     return await this.travelsRepository.save(travel);
   }


### PR DESCRIPTION
## 버그 설명
- `PUT Method: api/v1/travels`
- travel 수정 시 연계된 travel-detail id가 사라지면서 연관관계가 삭제되는 현상
- 수정필요