### PR TITLE
Feat: #51 가장 최근 다녀온 내가 생성한 여행과 내가 공유받은 여행 조회(상세 아님)

### DIFF
--- a/src/travel/controller/travels.controller.ts
+++ b/src/travel/controller/travels.controller.ts
@@ -121,6 +121,17 @@ export class TravelsController {
     return await this.travelsService.findTravelsDeepByUserId(userId);
   }
 
+  @Get('me/recent')
+  @ApiOperation({ summary: '가장 최근에 다녀온 내가 생성한 여행 조회' })
+  @ApiResponse({
+    status: 200,
+    description: '가장 최근에 다녀온 내가 생성한 여행 조회 성공',
+  })
+  async findRecentTravelByUserId(@Req() req: AuthRequest): Promise<Travels> {
+    const userId = getUserId(req);
+    return await this.travelsService.findRecentTravelByUserId(userId);
+  }
+
   @Get('me/shared')
   @ApiOperation({ summary: '내가 공유 받은 여행 조회' })
   @ApiResponse({
@@ -140,6 +151,18 @@ export class TravelsController {
   ): Promise<Travels[]> {
     const userId = getUserId(req);
     return await this.travelsService.findSharedTravelsByUser(userId, year);
+  }
+
+  @Get('me/shared/recent')
+  @UseGuards(UserGuard)
+  @ApiOperation({ summary: '내가 공유 받은 여행 중 가장 최근에 다녀온 여행 조회' })
+  @ApiResponse({
+    status: 200,
+    description: '내가 공유 받은 여행 중 가장 최근에 다녀온 여행 조회 성공',
+  })
+  async findRecentSharedTravelByUser(@Req() req: AuthRequest): Promise<Travels> {
+    const userId = getUserId(req);
+    return await this.travelsService.findRecentSharedTravelByUser(userId);
   }
 
   @Get('me/shared/years')

--- a/src/travel/service/travel-members.service.ts
+++ b/src/travel/service/travel-members.service.ts
@@ -114,6 +114,26 @@ export class TravelMembersService extends SearchFilterService {
   }
 
   /**
+   * 특정 멤버가 공유받은 가장 최근에 다녀온 여행 조회
+   *
+   * @param user
+   */
+  async findRecentSharedTravelByUser(user: Users): Promise<Travels> {
+    const travel = await this.travelMembersRepository
+      .createQueryBuilder('travelMembers')
+      .innerJoinAndSelect('travelMembers.travel', 'travels')
+      .where('travelMembers.user_id = :userId', { userId: user._id })
+      .orderBy('travels.startDate', 'DESC')
+      .getOne();
+
+    if (!travel) {
+      return null;
+    }
+
+    return travel.travel;
+  }
+
+  /**
    * 특정 멤버가 공유받은 여행들의 연도 리스트 조회
    *
    * @param user

--- a/src/travel/service/travels.service.ts
+++ b/src/travel/service/travels.service.ts
@@ -173,6 +173,24 @@ export class TravelsService extends SearchFilterService {
   }
 
   /**
+   * userId로 가장 최근에 다녀온 내가 생성한 여행 조회
+   */
+  async findRecentTravelByUserId(userId: bigint): Promise<Travels> {
+    const travel = await this.travelsRepository
+      .createQueryBuilder('travels')
+      .innerJoinAndSelect('travels.creator', 'users')
+      .where('users._id = :userId', { userId })
+      .orderBy('travels.startDate', 'DESC')
+      .getOne();
+
+    if (!travel) {
+      throw new Error(`No recent travel found for user with ID "${userId}"`);
+    }
+
+    return travel;
+  }
+
+  /**
    * userId와 travelId로 생성한 여행 조회
    *
    * @param userId
@@ -214,6 +232,20 @@ export class TravelsService extends SearchFilterService {
     }
 
     return this.travelMembersService.findSharedTravelsByUser(user, year);
+  }
+
+  /**
+   * 특정 멤버가 공유받은 가장 최근에 다녀온 여행 조회
+   *
+   * @param userId
+   */
+  async findRecentSharedTravelByUser(userId: bigint): Promise<Travels> {
+    const user = await this.userService.findOne(userId);
+    if (!user) {
+      throw new Error(`User with ID "${userId}" not found`);
+    }
+
+    return await this.travelMembersService.findRecentSharedTravelByUser(user)
   }
 
   /**


### PR DESCRIPTION
## 기능 설명
- 가장 최근 다녀온 내가 생성한 여행과 내가 공유받은 여행 조회(상세 아님)

## 구현내용
- 가장 최근에 다녀온 공유받은 여행 조회
  - /api/v1/travels/me/shared/recent
    <img width="1407" alt="image" src="https://github.com/user-attachments/assets/c75f9103-b617-4688-a755-c78491694197">

- 가장 최근에 다녀온 생성한 여행 조회
  - /api/v1/travels/me/recent
    <img width="1403" alt="image" src="https://github.com/user-attachments/assets/18614a23-8884-486d-b9d2-b45dbed70aa8">
